### PR TITLE
Fix/advertising bug fixes

### DIFF
--- a/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/BrightcovePlayerActivity.kt
+++ b/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/BrightcovePlayerActivity.kt
@@ -139,6 +139,7 @@ class BrightcovePlayerActivity : AppCompatActivity(), ErrorDialogListener {
             if (isVideoPaused) {
                 videoView.start()
             } else {
+                videoView.start()
                 configureVideo()
             }
             isVideoPaused = false

--- a/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/BrightcovePlayerActivity.kt
+++ b/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/BrightcovePlayerActivity.kt
@@ -67,6 +67,20 @@ class BrightcovePlayerActivity : AppCompatActivity(), ErrorDialogListener {
         videoView.listenVideoPlayError()
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (this::adsAdapter.isInitialized) {
+            adsAdapter.resumePlayingAd()
+        }
+    }
+
+    override fun onPause() {
+        if (this::adsAdapter.isInitialized) {
+            adsAdapter.pausePlayingAd()
+        }
+        super.onPause()
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         analyticsAdapter.endTrack(playable, FULLSCREEN)

--- a/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/BrightcovePlayerAdapter.kt
+++ b/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/BrightcovePlayerAdapter.kt
@@ -30,6 +30,7 @@ class BrightcovePlayerAdapter : BasePlayer(), ErrorDialogListener {
     private lateinit var adsAdapter: AdsAdapter
     private lateinit var viewGroup: ViewGroup
     private var errorDialog: ErrorDialog? = null
+    private var isErrorDialogVisible: Boolean = false
 
     /**
      * initialization of the player instance with a playable item
@@ -147,9 +148,11 @@ class BrightcovePlayerAdapter : BasePlayer(), ErrorDialogListener {
     }
 
     override fun onRefresh() {
-        if (errorDialog?.isConnectionEstablished() == true)
+        if (errorDialog?.isConnectionEstablished() == true) {
             errorDialog?.dismiss()
             videoView.start()
+            isErrorDialogVisible = false
+        }
     }
 
     override fun onBack() {
@@ -161,7 +164,9 @@ class BrightcovePlayerAdapter : BasePlayer(), ErrorDialogListener {
         videoView.eventEmitter.on(
             "Video Play Error"
         ) {
-            if (errorDialog == null || errorDialog?.isVisible == false) {
+            adsAdapter.onVideoPlayFailed(true)
+            if (errorDialog == null || !isErrorDialogVisible) {
+                isErrorDialogVisible = true
                 errorDialog = ErrorDialog.newInstance(this.pluginConfigurationParams)
                 errorDialog?.setOnErrorDialogListener(this)
                 errorDialog?.show((this.context as? AppCompatActivity)?.supportFragmentManager, "ErrorDialog")

--- a/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/BrightcovePlayerAdapter.kt
+++ b/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/BrightcovePlayerAdapter.kt
@@ -128,7 +128,11 @@ class BrightcovePlayerAdapter : BasePlayer(), ErrorDialogListener {
      */
     override fun pauseInline() {
         super.pauseInline()
-        videoView.pause()
+        if (this::adsAdapter.isInitialized) {
+            (adsAdapter as GoogleIMAAdapter).pausePlayingAd()
+        }
+        if (videoView != null && videoView.isPlaying)
+            videoView.pause()
     }
 
     /**
@@ -137,6 +141,9 @@ class BrightcovePlayerAdapter : BasePlayer(), ErrorDialogListener {
     override fun resumeInline() {
         super.resumeInline()
         videoView.start()
+        if (this::adsAdapter.isInitialized) {
+            (adsAdapter as GoogleIMAAdapter).resumePlayingAd()
+        }
     }
 
     override fun onRefresh() {

--- a/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ErrorDialog.kt
+++ b/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ErrorDialog.kt
@@ -140,8 +140,8 @@ class ErrorDialog : DialogFragment(), View.OnClickListener {
     fun isConnectionEstablished() = isNetworkAvailable()
 
     private fun isNetworkAvailable(): Boolean {
-        val conMgr = this.context?.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        return (conMgr.activeNetworkInfo != null
+        val conMgr = this.context?.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+        return (conMgr?.activeNetworkInfo != null
                 && conMgr.activeNetworkInfo.isAvailable
                 && conMgr.activeNetworkInfo.isConnected)
     }

--- a/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ErrorDialog.kt
+++ b/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ErrorDialog.kt
@@ -157,11 +157,13 @@ class ErrorDialog : DialogFragment(), View.OnClickListener {
         /**
          *  Creates a new instance of this dialog and returns it.
          */
-        fun newInstance(pluginConfigurationParams: Map<*, *>): ErrorDialog {
+        fun newInstance(pluginConfigurationParams: Map<*, *>?): ErrorDialog {
             val dialog = ErrorDialog()
             val bundle = Bundle()
-            bundle.apply {
-                putSerializable(KEY_PLUGIN_CONFIGURATION, pluginConfigurationParams as LinkedTreeMap<*, *>)
+            if (pluginConfigurationParams != null) {
+                bundle.apply {
+                    putSerializable(KEY_PLUGIN_CONFIGURATION, pluginConfigurationParams as LinkedTreeMap<*, *>)
+                }
             }
             dialog.arguments = bundle
             return dialog

--- a/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ad/APVideoAdPlayerCallback.kt
+++ b/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ad/APVideoAdPlayerCallback.kt
@@ -1,0 +1,20 @@
+package com.applicaster.player.plugins.brightcove.ad
+
+import com.google.ads.interactivemedia.v3.api.player.VideoAdPlayer
+
+abstract class APVideoAdPlayerCallback : VideoAdPlayer.VideoAdPlayerCallback {
+    override fun onVolumeChanged(p0: Int) {}
+
+    override fun onResume() {}
+
+    override fun onPause() { onVideoAdPaused() }
+
+    override fun onError() {}
+
+    override fun onEnded() { onVideoAdEnded() }
+
+    override fun onPlay() {}
+
+    abstract fun onVideoAdPaused()
+    abstract fun onVideoAdEnded()
+}

--- a/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ad/AdsAdapter.kt
+++ b/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ad/AdsAdapter.kt
@@ -84,6 +84,8 @@ abstract class VideoAdsAdapter(private val videoView: BrightcoveVideoView) :
     protected fun getAds() = ads
 
     protected abstract fun setupAdsPlugin()
+    abstract fun resumePlayingAd()
+    abstract fun pausePlayingAd()
 
     companion object {
         const val TAG = "VideoAdsAdapter"

--- a/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ad/AdsAdapter.kt
+++ b/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ad/AdsAdapter.kt
@@ -9,6 +9,10 @@ import com.brightcove.player.view.BrightcoveVideoView
 
 interface AdsAdapter {
     fun setupForVideo(playable: Playable)
+    fun resumePlayingAd()
+    fun pausePlayingAd()
+    fun isPostrollSetUp(): Boolean
+    fun onVideoPlayFailed(isPlayerFailed: Boolean)
 }
 
 abstract class VideoAdsAdapter(private val videoView: BrightcoveVideoView) :
@@ -82,8 +86,6 @@ abstract class VideoAdsAdapter(private val videoView: BrightcoveVideoView) :
     protected fun getAds() = ads
 
     protected abstract fun setupAdsPlugin()
-    abstract fun resumePlayingAd()
-    abstract fun pausePlayingAd()
 
     companion object {
         const val TAG = "VideoAdsAdapter"

--- a/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ad/AdsAdapter.kt
+++ b/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ad/AdsAdapter.kt
@@ -56,9 +56,10 @@ abstract class VideoAdsAdapter(private val videoView: BrightcoveVideoView) :
                 }
             } else {
                 // If we have VMAP ad type we should get only url field
-                val adsExtension = playable.entry.getExtension(VideoAd.KEY_VIDEO_AD_EXTENSION, Map::class.java)
-                if (adsExtension != null && adsExtension is Map) {
-                    parseSingleAd(adsExtension)
+                val adsExtension = playable.entry.getExtension(VideoAd.KEY_VIDEO_AD_EXTENSION, String::class.java)
+                if (adsExtension != null && adsExtension is String) {
+                    val url = adsExtension
+                    ads.add(VideoAd(url, null))
                 }
             }
         }
@@ -72,9 +73,6 @@ abstract class VideoAdsAdapter(private val videoView: BrightcoveVideoView) :
         }
         if (ad.containsKey(VideoAd.KEY_OFFSET)) {
             offset = ad[VideoAd.KEY_OFFSET].toString()
-        }
-        if (ad.containsKey(VideoAd.KEY_VIDEO_AD_EXTENSION)) {
-            url = ad[VideoAd.KEY_VIDEO_AD_EXTENSION].toString()
         }
         ads.add(VideoAd(url, offset))
     }

--- a/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ad/GoogleIMAAdapter.kt
+++ b/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/ad/GoogleIMAAdapter.kt
@@ -25,6 +25,7 @@ class GoogleIMAAdapter(private val videoView: BrightcoveVideoView) :
     private lateinit var container: AdDisplayContainer
     private var isPostrollSetUp: Boolean = false
     private var isVideoPlayFailed: Boolean = false
+    private var adsManager: AdsManager? = null
 
     override fun setupAdsPlugin() {
         setupGoogleIMA()
@@ -92,7 +93,7 @@ class GoogleIMAAdapter(private val videoView: BrightcoveVideoView) :
                 GoogleIMAEventType.ADS_MANAGER_LOADED
             ) { event ->
                 if (adType == VideoAd.AdType.VMAP) {
-                    val adsManager = event.properties["adsManager"] as? AdsManager?
+                    adsManager = event.properties["adsManager"] as? AdsManager?
                     vmapCuePoints = adsManager?.adCuePoints
                 }
             }

--- a/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/analytics/ErrorHandlingVideoPlayerAdapter.kt
+++ b/Android/brightcove-player-plugin/src/main/java/com/applicaster/player/plugins/brightcove/analytics/ErrorHandlingVideoPlayerAdapter.kt
@@ -8,6 +8,7 @@ import com.brightcove.player.event.EventType
 import com.brightcove.player.model.Source
 import com.brightcove.player.model.Video
 import com.brightcove.player.view.BrightcoveVideoView
+import com.google.ads.interactivemedia.v3.api.AdError
 
 class ErrorHandlingVideoPlayerAdapter(private val videoView: BrightcoveVideoView): ErrorHandlingAnalyticsAdapter(videoView) {
 
@@ -46,9 +47,13 @@ class ErrorHandlingVideoPlayerAdapter(private val videoView: BrightcoveVideoView
                 analyticsParams
             )
 
-            videoView.eventEmitter.emit(
-                playable.videoPlayErrorEvent
-            )
+            //Check if error type is not AdError
+            if (
+                event.properties.containsKey(EventType.ERROR)
+                && event.properties[EventType.ERROR] !is AdError
+            ) {
+                videoView.eventEmitter.emit(playable.videoPlayErrorEvent)
+            }
         }
     }
 


### PR DESCRIPTION
## Description
1. Fixed issue: video gets stuck after clicking "Read More" and returning.
2. Fixed issue: VMAP ads are not displaying.
3. Fixed issue: video gets stuck after going to the background while ad is playing.
4. Fixed issue: player not closing after video playback is complete or after the postroll ends.
5. Added check of plugin configuration params on null, added check of video play error on correct type - this could lead to incorrect error UI behaviour.
