### PR TITLE
Fix/ios brightcove advertising fixes

### DIFF
--- a/iOS/PluginClasses/AdvertisementParser.swift
+++ b/iOS/PluginClasses/AdvertisementParser.swift
@@ -46,7 +46,7 @@ class AdvertisementParser {
         switch advertisementData {
         case let url as String:
             parsedAdvertisement = .vmap(url)
-        case let vastAdList as Array<NSDictionary>:
+        case let vastAdList as Array<Any>:
             parseVastAdList(vastAdList: vastAdList)
         default:
             break
@@ -55,9 +55,12 @@ class AdvertisementParser {
     
     // MARK: - Private methods
     
-    private func parseVastAdList(vastAdList: [NSDictionary]) {
+    private func parseVastAdList(vastAdList: [Any]) {// [Any], because in configuration preroll/postroll only, array consist empty string ([NSDisctionary(postroll),""])
         var parsedAdList: [VastAdvertisement] = []
         for advertisement in vastAdList {
+            guard let advertisement = advertisement as? NSDictionary else { //skip empty string in case of postroll/preroll only
+                continue
+            }
             guard let url = advertisement.value(forKey: VideoExtensionAdsKeys.adURL.rawValue) as? String,
                 let offset = wrapOffsetToString(offset: advertisement.value(forKey: VideoExtensionAdsKeys.offset.rawValue)),
                 let vast = createVast(withUrl: url, andOffset: offset) else {

--- a/iOS/PluginClasses/AdvertisementParser.swift
+++ b/iOS/PluginClasses/AdvertisementParser.swift
@@ -59,7 +59,7 @@ class AdvertisementParser {
         var parsedAdList: [VastAdvertisement] = []
         for advertisement in vastAdList {
             guard let url = advertisement.value(forKey: VideoExtensionAdsKeys.adURL.rawValue) as? String,
-                let offset = advertisement.value(forKey: VideoExtensionAdsKeys.offset.rawValue) as? String,
+                let offset = wrapOffsetToString(offset: advertisement.value(forKey: VideoExtensionAdsKeys.offset.rawValue)),
                 let vast = createVast(withUrl: url, andOffset: offset) else {
                 continue
             }
@@ -68,6 +68,16 @@ class AdvertisementParser {
         }
         
         parsedAdvertisement = .vast(parsedAdList)
+    }
+    
+    private func wrapOffsetToString(offset: Any?) -> String? { // convert offset different types (possible values: "preroll","postroll","90", 90) to String?
+        if let result = offset as? String {
+            return result
+        }
+        if let result = offset as? Double {
+            return String(result)
+        }
+        return nil
     }
     
     private func createVast(withUrl url: String,

--- a/iOS/PluginClasses/PlayerViewController.swift
+++ b/iOS/PluginClasses/PlayerViewController.swift
@@ -38,6 +38,7 @@ class PlayerViewController: UIViewController, IMAWebOpenerDelegate, PlaybackEven
     weak var delegate: PlayerAdvertisementEventsDelegate?
     weak var analyticEventDelegate: PlaybackAnalyticEventsDelegate?
     
+    var isContentPaused = false
     // MARK: - Lifecycle
     
     required init(builder: PlayerViewBuilderProtocol, player: PlayerAdapterProtocol) {
@@ -126,13 +127,21 @@ class PlayerViewController: UIViewController, IMAWebOpenerDelegate, PlaybackEven
     
     @objc private func wentBackground() {
         if view.window != nil {
-            player.pause()
+            if isContentPaused {
+                player.player.pauseAd()
+            } else {
+                player.pause()
+            }
         }
     }
     
     @objc private func wentForeground() {
         if view.window != nil {
-            player.resume()
+            if isContentPaused {
+                player.player.resumeAd()
+            } else {
+                player.resume()
+            }
         }
     }
     
@@ -208,6 +217,10 @@ class PlayerViewController: UIViewController, IMAWebOpenerDelegate, PlaybackEven
             errorView?.removeFromSuperview()
             isAdPlaybackBlocked = false
             break
+        case kBCOVIMALifecycleEventAdsManagerDidRequestContentPause:
+            isContentPaused = true
+        case kBCOVIMALifecycleEventAdsManagerDidRequestContentResume:
+            isContentPaused = false
         default:
             break
         }


### PR DESCRIPTION
## Fixes
OPT-14 - Midrolls are not running when running from the DSP
OPT-16 - Video gets stuck when going to the background in the middle of an ad and returning
OPT-17 - Preroll Only / Postroll Only doesn't work from XML